### PR TITLE
Fixed syntax errors in translation files

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.1.2 - unreleased
+--------------------
+
+- Fixed syntax errors in po translation files.
+  [SyZn]
+
 1.1.1 - (2011-10-27)
 --------------------
 

--- a/netsight/async/locales/de/LC_MESSAGES/netsight.async.po
+++ b/netsight/async/locales/de/LC_MESSAGES/netsight.async.po
@@ -1,3 +1,5 @@
+msgid ""
+msgstr ""
 "Project-Id-Version: netsight.async-0.0.1\n"
 "Report-Msgid-Bugs-To: support@netsight.co.uk\n"
 

--- a/netsight/async/locales/en/LC_MESSAGES/netsight.async.po
+++ b/netsight/async/locales/en/LC_MESSAGES/netsight.async.po
@@ -1,3 +1,5 @@
+msgid ""
+msgstr ""
 "Project-Id-Version: netsight.async-0.0.1\n"
 "Report-Msgid-Bugs-To: support@netsight.co.uk\n"
 

--- a/netsight/async/locales/it/LC_MESSAGES/netsight.async.po
+++ b/netsight/async/locales/it/LC_MESSAGES/netsight.async.po
@@ -1,3 +1,5 @@
+msgid ""
+msgstr ""
 "Project-Id-Version: netsight.async-0.0.1\n"
 "Report-Msgid-Bugs-To: support@netsight.co.uk\n"
 


### PR DESCRIPTION
Due to some translation file syntax errors these were not compiling correctly. I've fixed that.
